### PR TITLE
🩹 [Patch]: Cleanup code that is managed in `Build-PSModule`

### DIFF
--- a/scripts/helpers/Build-PSModuleDocumentation.ps1
+++ b/scripts/helpers/Build-PSModuleDocumentation.ps1
@@ -1,5 +1,5 @@
-﻿#Requires -Modules @{ ModuleName = 'GitHub'; ModuleVersion = '0.13.2' }
-#Requires -Modules @{ ModuleName = 'Utilities'; ModuleVersion = '0.3.0' }
+﻿#Requires -Modules GitHub
+#Requires -Modules Utilities
 
 function Build-PSModuleDocumentation {
     <#

--- a/scripts/helpers/Import-PSModule.ps1
+++ b/scripts/helpers/Import-PSModule.ps1
@@ -1,4 +1,4 @@
-﻿#Requires -Modules @{ ModuleName = 'Utilities'; ModuleVersion = '0.3.0' }
+﻿#Requires -Modules Utilities
 
 function Import-PSModule {
     <#

--- a/scripts/helpers/Resolve-PSModuleDependency.ps1
+++ b/scripts/helpers/Resolve-PSModuleDependency.ps1
@@ -1,4 +1,4 @@
-﻿#Requires -Modules @{ ModuleName = 'Retry'; ModuleVersion = '0.1.3' }
+﻿#Requires -Modules Retry
 
 function Resolve-PSModuleDependency {
     <#

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -30,19 +30,6 @@ LogGroup 'Loading inputs' {
     Write-Host "Docs output path:    [$docsOutputFolderPath]"
 }
 
-LogGroup 'Build local scripts' {
-    Write-Host 'Execution order:'
-    $scripts = Get-ChildItem -Filter '*build.ps1' -Recurse | Sort-Object -Property Name | Resolve-Path -Relative
-    $scripts | ForEach-Object {
-        Write-Host " - $_"
-    }
-    $scripts | ForEach-Object {
-        LogGroup "Build local scripts - [$_]" {
-            . $_
-        }
-    }
-}
-
 $params = @{
     ModuleName              = $moduleName
     ModuleSourceFolderPath  = $moduleSourceFolderPath


### PR DESCRIPTION
## Description

This pull request includes changes to streamline the module requirements and clean up the script execution order in the PowerShell scripts. 

* Removed version specifications from the `#Requires -Modules` statements.
* Deleted the block of code that builds local scripts, which included retrieving and executing build scripts in a specific order.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
