### PR TITLE
🩹 [Patch]: Update tests to perform a linter evaluation

### DIFF
--- a/.github/workflows/Action-Test.yml
+++ b/.github/workflows/Action-Test.yml
@@ -15,7 +15,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-permissions: {}
+permissions:
+  contents: read # to checkout the repo
+  statuses: write # to create commit status
 
 jobs:
   ActionTestDefault:
@@ -24,6 +26,9 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+          fetch-depth: 0
 
       - name: Upload module artifact
         uses: actions/upload-artifact@v4
@@ -38,3 +43,21 @@ jobs:
         with:
           Name: PSModuleTest
           WorkingDirectory: tests/srcTestRepo
+
+      - name: Get changes
+        uses: PSModule/GitHub-Script@v1
+        with:
+          Script: |
+            LogGroup "List files" {
+              Get-ChildItem -Recurse -File | Select-Object -ExpandProperty FullName | Sort-Object
+            }
+            LogGroup "Commit changes" {
+              git add tests/srcTestRepo/outputs/docs/
+              git commit -m "Update documentation"
+            }
+
+      - name: Lint documentation
+        uses: super-linter/super-linter/slim@7bba2eeb89d01dc9bfd93c497477a57e72c83240 # v8.2.0
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          VALIDATE_MARKDOWN: true

--- a/scripts/helpers/Build-PSModuleDocumentation.ps1
+++ b/scripts/helpers/Build-PSModuleDocumentation.ps1
@@ -48,7 +48,7 @@
     Write-Host '::group::Build docs - Generate markdown help - Raw'
     Install-PSModule -Path $ModuleOutputFolder
     Write-Host ($ModuleName | Get-Module)
-    $null = New-MarkdownHelp -Module $ModuleName -OutputFolder $DocsOutputFolder -Force -Verbose
+    $null = New-MarkdownHelp -Module $ModuleName -OutputFolder $DocsOutputFolder -Force -Encoding UTF8
     Get-ChildItem -Path $DocsOutputFolder -Recurse -Force -Include '*.md' | ForEach-Object {
         $fileName = $_.Name
         Write-Host "::group:: - [$fileName]"

--- a/tests/srcTestRepo/outputs/module/PSModuleTest/PSModuleTest.psm1
+++ b/tests/srcTestRepo/outputs/module/PSModuleTest/PSModuleTest.psm1
@@ -314,6 +314,12 @@ function Set-PSModuleTest {
         Test-PSModule -Name 'World'
 
         "Hello, World!"
+
+        .NOTES
+        Controls:
+        - :q      : Quit
+        - :q!     : Quit without saving
+        - :wq     : Save and quit
     #>
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
         'PSUseShouldProcessForStateChangingFunctions', '', Scope = 'Function',

--- a/tests/srcTestRepo/src/functions/public/SomethingElse/Set-PSModuleTest.ps1
+++ b/tests/srcTestRepo/src/functions/public/SomethingElse/Set-PSModuleTest.ps1
@@ -7,6 +7,12 @@
         Test-PSModule -Name 'World'
 
         "Hello, World!"
+
+        .NOTES
+        Controls:
+        - :q      : Quit
+        - :q!     : Quit without saving
+        - :wq     : Save and quit
     #>
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
         'PSUseShouldProcessForStateChangingFunctions', '', Scope = 'Function',


### PR DESCRIPTION
## Description

This pull request updates the GitHub Actions workflow for testing and enhances documentation in the `Set-PSModuleTest` function. The most significant changes include improving workflow permissions, adding steps for documentation linting, and updating function notes.

**GitHub Actions workflow improvements:**

* Updated `.github/workflows/Action-Test.yml` to explicitly set permissions for reading repository contents and writing commit statuses, improving workflow security and clarity.
* Enhanced the checkout step to disable credential persistence and fetch the full history, supporting more advanced CI operations.
* Added steps to list files, commit documentation changes, and run a markdown linter (`super-linter`) to ensure documentation quality.

**Documentation enhancements:**

* Added a `.NOTES` section to the `Set-PSModuleTest` function in both `PSModuleTest.psm1` and `Set-PSModuleTest.ps1`, documenting common control commands (e.g., `:q`, `:q!`, `:wq`). [[1]](diffhunk://#diff-b6253bdc18cdabe21d009dc3778e7ef0d84effe3d28242d670a938b0f710920cR317-R322) [[2]](diffhunk://#diff-1d4bb1ca6780e5c612c9b2db51bb1c07c381ef6608cd52a7780ec786ad6946cdR10-R15)
