### PR TITLE
🩹[Patch]: Improve error handling and output error summary

### DIFF
--- a/scripts/helpers/Build-PSModuleDocumentation.ps1
+++ b/scripts/helpers/Build-PSModuleDocumentation.ps1
@@ -85,7 +85,7 @@
                     Error       = $_
                     ErrorString = $_.ToString()
                 })
-            Write-Error $_
+            Write-Warning "Failed to generate markdown help for $($command.Name): $_"
         }
     }
     Write-Host '::endgroup::'

--- a/tests/srcTestRepo/outputs/module/PSModuleTest/PSModuleTest.psm1
+++ b/tests/srcTestRepo/outputs/module/PSModuleTest/PSModuleTest.psm1
@@ -256,6 +256,9 @@ function Get-PSModuleTest {
         .SYNOPSIS
         Performs tests on a module.
 
+        .DESCRIPTION
+        Performs tests on a module.
+
         .EXAMPLE
         Test-PSModule -Name 'World'
 
@@ -280,6 +283,9 @@ Write-Verbose "[$scriptName] - [/public/New-PSModuleTest.ps1] - Importing"
 function New-PSModuleTest {
     <#
         .SYNOPSIS
+        Performs tests on a module.
+
+        .DESCRIPTION
         Performs tests on a module.
 
         .EXAMPLE

--- a/tests/srcTestRepo/outputs/module/PSModuleTest/PSModuleTest.psm1
+++ b/tests/srcTestRepo/outputs/module/PSModuleTest/PSModuleTest.psm1
@@ -256,9 +256,6 @@ function Get-PSModuleTest {
         .SYNOPSIS
         Performs tests on a module.
 
-        .DESCRIPTION
-        Performs tests on a module.
-
         .EXAMPLE
         Test-PSModule -Name 'World'
 
@@ -283,9 +280,6 @@ Write-Verbose "[$scriptName] - [/public/New-PSModuleTest.ps1] - Importing"
 function New-PSModuleTest {
     <#
         .SYNOPSIS
-        Performs tests on a module.
-
-        .DESCRIPTION
         Performs tests on a module.
 
         .EXAMPLE


### PR DESCRIPTION
## Description

This pull request makes a minor improvement to error handling in the PowerShell documentation build script. Instead of writing errors as errors, it now logs them as warnings with more context when markdown help generation fails for a command.

* Improved error reporting by changing `Write-Error` to `Write-Warning` with a descriptive message in `Build-PSModuleDocumentation.ps1`.
